### PR TITLE
[fix] accounting for file extensions in upper case

### DIFF
--- a/filetype.go
+++ b/filetype.go
@@ -3,6 +3,7 @@ package wfs
 import (
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 var types map[string]string
@@ -55,7 +56,7 @@ func getType(info os.FileInfo) string {
 		return "file"
 	}
 
-	ftype, ok := types[ext[1:]]
+	ftype, ok := types[strings.ToLower(ext[1:])]
 	if !ok {
 		return "file"
 	}


### PR DESCRIPTION
sometimes there are files with extension in the upper case, e.g. saw a couple of MP4 files. (seems that some devices name their files like this, it was a video camera).